### PR TITLE
remove broken link

### DIFF
--- a/docs/source/resources.md
+++ b/docs/source/resources.md
@@ -6,5 +6,4 @@ publications
 contact
 developers/index
 Sample datasets <https://gin.g-node.org/BrainGlobe>
-Old documentation <https://docs.brainglobe.info>
 :::


### PR DESCRIPTION
Remove a link to the old docs for now. It isn't directing properly to the old gitbook site (yet). Related to https://github.com/brainglobe/website/issues/20