### PR TITLE
Feedback on dev docs

### DIFF
--- a/docs/source/developers/index.md
+++ b/docs/source/developers/index.md
@@ -1,4 +1,4 @@
-# Developers guide
+# Developer's guide
 
 ## Introduction
 

--- a/docs/source/developers/index.md
+++ b/docs/source/developers/index.md
@@ -5,7 +5,7 @@
 **Contributors to BrainGlobe are absolutely encouraged**, whether to fix a bug, develop a new feature, or add a new atlas.
 
 There are many BrainGlobe repositories, so it may not be obvious where a new contribution should go.
-If you're unsure about any part of the contributing process, please get in touch. The best place is to start a new discussion on
+If you're unsure about any part of the contributing process, please [get in touch](../contact.md). The best place is to start a new discussion on
 the [image.sc forum](https://forum.image.sc/tag/brainglobe). If you tag your post with `brainglobe` (and optionally a
 specific tool, e.g. `cellfinder`) we will see your question and respond as soon as we can.
 

--- a/docs/source/documentation/general/conda.md
+++ b/docs/source/documentation/general/conda.md
@@ -102,4 +102,4 @@ The reason why we use conda environments (other methods other than conda are ava
 installations. This way, anything we do in the environment shouldn't affect any of the other environments.
 
 If anything goes wrong, and your software stops working (and can't be fixed), you can simply make a new environment, 
-and start again. If you have any troubles though, please get in touch.
+and start again. If you have any troubles though, please [get in touch](../../contact.md).

--- a/docs/source/documentation/general/conda.md
+++ b/docs/source/documentation/general/conda.md
@@ -19,7 +19,7 @@ some new features of the latest release for another.
 
 :::{hint}
 If you know what you're doing with virtual environments, feel free to ignore this, but conda does make 
-[CUDA and cuDNN installation easier](gpu)).
+[CUDA and cuDNN installation easier](gpu).
 :::
 
 ## Installation

--- a/docs/source/documentation/general/gpu.md
+++ b/docs/source/documentation/general/gpu.md
@@ -41,6 +41,6 @@ conda install -c conda-forge cudatoolkit=11.2 cudnn=8.1.0
 
 This method is easier and also doesn't require any admin rights (useful on a cluster or shared machine).
 
-if this does not work for any reason, or you wish to have a system-wide installation of CUDA and cuDNN, then CUDA can 
+If this does not work for any reason, or you wish to have a system-wide installation of CUDA and cuDNN, then CUDA can 
 be downloaded [here](https://developer.nvidia.com/cuda-toolkit-archive) and cuDNN from 
 [here](https://developer.nvidia.com/cudnn). N.B. you will need to sign up for a (free) account to download cuDNN.

--- a/docs/source/documentation/general/image-definition.md
+++ b/docs/source/documentation/general/image-definition.md
@@ -1,4 +1,4 @@
-# Image definition
+# Image space definition
 
 In some BrainGlobe tools, you need to specify the orientation and resolution of the data.
 
@@ -7,7 +7,7 @@ When you need to specify the orientation of your data, you will usually need to 
 [bg-space](https://github.com/brainglobe/bg-space) "initials" form, to describe the origin voxel.
 
 When you work with a stack, the origin is the upper left corner when you show the first element `stack[0, :, :]` with 
-matplotlib or when you open the stack with ImageJ. The First dimension is the one that you are slicing, the second is 
+matplotlib or when you open the stack with ImageJ. The first dimension is the one that you are slicing, the second is 
 the height of the image, and the third is the width of the image.
 
 If the origin of your data (first, top left voxel) is the most anterior, superior, left part of the brain, then the 


### PR DESCRIPTION
Fixes small typos and adds some suggestions to:
- the documentation page
- the developers guide page

### Some comments
- For me in the General BrainGlobe documentation, the links to anaconda open in the same tab. If these are considered external, should they open in a separate one? As @adamltyson pointed out, in [numpy](https://numpy.org/install/) and others anaconda links also open in the same tab, so maybe we just leave it as it is.
- I changed "developers" to "developer's" but not sure what is correct tbh. Found a few examples of "Developer's" but native speakers here disagree...
- I also suggested a new title for the "Image definition" section. Initially it made me think it was about image resolution, so I wonder if "image space definition" or "coordinate space definition/convention" is a bit more clear?
-  In the left hand side navigation panel, "cellfinder" and "cellfinder-core" appear under 'Developers guide', but 'cellfinder' also appears later outside 'Developers guide'.