### PR TITLE
remove sphinx version constraint

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx>=5.0,<6.0
+sphinx
 pydata-sphinx-theme
 myst-parser
 numpydoc


### PR DESCRIPTION
With the v2 docs deployment workflow, it's no longer necessary to constrain Sphinx to <6.
