### PR TITLE
ensure image URLs are on new lines

### DIFF
--- a/docs/source/tutorials/visualise-atlas-napari.md
+++ b/docs/source/tutorials/visualise-atlas-napari.md
@@ -14,6 +14,7 @@ You will need `napari` installed on your computer - please follow [`napari`'s in
 **The brainrender widget appears on the right hand side of the window.**
 
 4. In the `brainrender` widget's `Atlas table view` section, double-click the row which contains the `mpin_zfish_1um` atlas (you may have to scroll down slightly).
+
 ![brainrender widget with added annotations](./images/brainrender-napari/added-brainrender-napari.png)
 
 **You have now added the annotations image and the default reference image to napari: They appear as layers in the napari layers list on the lower left of the window. A `3D Atlas region meshes` section appears below the `Atlas table view` section.**
@@ -24,14 +25,17 @@ If you haven't downloaded the atlas before, the plugin will prompt you to downlo
 :::
 
 5. Toggle the napari display from 2D to 3D by pressing the button with the square icon on the lower left of the window.
+
 ![brainrender widget with 3d display](./images/brainrender-napari/toggle-ndisplay-brainrender-napari.png)
 
 **The annotations image should now be displayed in 3D.**
 6. Navigate the brain region tree in the `3D Atlas region meshes` section by opening "forebrain". Double-click on `telencephalon`.
+
 ![brainrender widget with region mesh](./images/brainrender-napari/add-region-brainrender-napari.png)
 
  **You have now added a 3D atlas region mesh layer, which appears as a mesh in the viewer and as a new layer in the layers list.**
 7. Back in the "Atlas table view" section, right-click on the `mpin_zfish_1um` row. In the menu that appears, select `GAD1b`.
+
 ![brainrender widget with additional reference](./images/brainrender-napari/additional-reference-brainrender-napari.png)
 
 **You have now added an additional reference image, which appears as a grey scale image in the viewer and as a new layer in the layers list.**


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
<img width="863" alt="Screenshot 2023-09-11 at 17 12 20" src="https://github.com/brainglobe/website/assets/10500965/c4cdfcd9-e60b-48dd-b08e-f9fed1f7723c">

**What does this PR do?**

Ensures the images references in the `brainrender-napari` tutorial are separated from previous and subsequent content by empty lines, to avoid what happens in the screenshot above.

## References
Just the screenshot above. Have noticed and fixed without opening an issue for speed.

## How has this PR been tested?

Didn't test, but naively confident this is the problem.

## Is this a breaking change?

Nope

## Does this PR require an update to the documentation?

Nope

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
